### PR TITLE
feat(004-LOGIN_CUSTOMER): 커스터머(고객)에 대한 로그인 구현

### DIFF
--- a/.idea/compiler.xml
+++ b/.idea/compiler.xml
@@ -8,6 +8,7 @@
           <entry name="$USER_HOME$/.gradle/caches/modules-2/files-2.1/org.projectlombok/lombok/1.18.22/9c08ea24c6eb714e2d6170e8122c069a0ba9aacf/lombok-1.18.22.jar" />
         </processorPath>
         <module name="zerobase-cms.user-api.main" />
+        <module name="zerobase-cms.zerobase-domain.main" />
         <module name="zerobase-cms.main" />
       </profile>
     </annotationProcessing>

--- a/.idea/gradle.xml
+++ b/.idea/gradle.xml
@@ -11,6 +11,7 @@
           <set>
             <option value="$PROJECT_DIR$" />
             <option value="$PROJECT_DIR$/user-api" />
+            <option value="$PROJECT_DIR$/zerobase-domain" />
           </set>
         </option>
       </GradleProjectSettings>

--- a/.idea/modules.xml
+++ b/.idea/modules.xml
@@ -4,6 +4,7 @@
     <modules>
       <module fileurl="file://$PROJECT_DIR$/.idea/modules/zerobase-cms.main.iml" filepath="$PROJECT_DIR$/.idea/modules/zerobase-cms.main.iml" />
       <module fileurl="file://$PROJECT_DIR$/.idea/modules/user-api/zerobase-cms.user-api.main.iml" filepath="$PROJECT_DIR$/.idea/modules/user-api/zerobase-cms.user-api.main.iml" />
+      <module fileurl="file://$PROJECT_DIR$/.idea/modules/zerobase-domain/zerobase-cms.zerobase-domain.main.iml" filepath="$PROJECT_DIR$/.idea/modules/zerobase-domain/zerobase-cms.zerobase-domain.main.iml" />
     </modules>
   </component>
 </project>

--- a/settings.gradle
+++ b/settings.gradle
@@ -1,3 +1,4 @@
 rootProject.name = 'zerobase-cms'
 include 'user-api'
+include 'zerobase-domain'
 

--- a/user-api/src/main/java/com/zerobase/cms/user/UserApplication.java
+++ b/user-api/src/main/java/com/zerobase/cms/user/UserApplication.java
@@ -3,10 +3,12 @@ package com.zerobase.cms.user;
 import lombok.RequiredArgsConstructor;
 import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
+import org.springframework.boot.web.servlet.ServletComponentScan;
 import org.springframework.cloud.openfeign.EnableFeignClients;
 import org.springframework.data.jpa.repository.config.EnableJpaAuditing;
 import org.springframework.data.jpa.repository.config.EnableJpaRepositories;
 
+@ServletComponentScan
 @EnableFeignClients
 @SpringBootApplication
 @EnableJpaAuditing

--- a/user-api/src/main/java/com/zerobase/cms/user/application/SignInApplication.java
+++ b/user-api/src/main/java/com/zerobase/cms/user/application/SignInApplication.java
@@ -1,0 +1,30 @@
+package com.zerobase.cms.user.application;
+
+import com.zerobase.cms.user.client.domain.SignInform;
+import com.zerobase.cms.user.client.domain.model.Customer;
+import com.zerobase.cms.user.client.exception.CustomException;
+import com.zerobase.cms.user.client.exception.ErrorCode;
+import com.zerobase.cms.user.client.service.CustomerService;
+import com.zerobase.domain.common.UserType;
+import com.zerobase.domain.config.JwtAuthenticationProvider;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+
+@Service
+@RequiredArgsConstructor
+public class SignInApplication {
+
+    private final CustomerService customerService;
+    private final JwtAuthenticationProvider provider;
+
+    public String customerLoginToken(SignInform form) {
+        //1. 로그인 가능 여부
+        Customer c = customerService.findValidCustomer(form.getEmail(), form.getPassword())
+            .orElseThrow(() -> new CustomException(ErrorCode.LOGIN_CHECK_FAIL));
+        //2. 토큰을 발행
+        //3. 토큰을 Response
+
+        return provider.createToken(c.getEmail(), c.getId(), UserType.CUSTOMER);
+    }
+
+}

--- a/user-api/src/main/java/com/zerobase/cms/user/client/config/JwtConfig.java
+++ b/user-api/src/main/java/com/zerobase/cms/user/client/config/JwtConfig.java
@@ -1,0 +1,14 @@
+package com.zerobase.cms.user.client.config;
+
+import com.zerobase.domain.config.JwtAuthenticationProvider;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+
+@Configuration
+public class JwtConfig {
+
+    @Bean
+    public JwtAuthenticationProvider jwtAuthenticationProvider() {
+        return new JwtAuthenticationProvider();
+    }
+}

--- a/user-api/src/main/java/com/zerobase/cms/user/client/config/filter/CustomerFilter.java
+++ b/user-api/src/main/java/com/zerobase/cms/user/client/config/filter/CustomerFilter.java
@@ -1,0 +1,39 @@
+package com.zerobase.cms.user.client.config.filter;
+
+import com.zerobase.cms.user.client.service.CustomerService;
+import com.zerobase.domain.common.UserVo;
+import com.zerobase.domain.config.JwtAuthenticationProvider;
+import java.io.IOException;
+import javax.servlet.Filter;
+import javax.servlet.FilterChain;
+import javax.servlet.ServletException;
+import javax.servlet.ServletRequest;
+import javax.servlet.ServletResponse;
+import javax.servlet.annotation.WebFilter;
+import javax.servlet.http.HttpServletRequest;
+import lombok.RequiredArgsConstructor;
+
+@WebFilter(urlPatterns = "/customer/*")
+@RequiredArgsConstructor
+public class CustomerFilter implements Filter {
+
+    private final JwtAuthenticationProvider jwtAuthenticationProvider;
+    private final CustomerService customerService;
+
+
+    @Override
+    public void doFilter(ServletRequest request, ServletResponse response, FilterChain chain)
+        throws IOException, ServletException {
+        HttpServletRequest req = (HttpServletRequest) request;
+        String token = req.getHeader("X-AUTH-TOKEN");
+        if (!jwtAuthenticationProvider.validateToken(token)) {
+            throw new ServletException("Invalid Access");
+        }
+        UserVo vo = jwtAuthenticationProvider.getUserVo(token);
+        customerService.findByIdAndEmail(vo.getId(), vo.getEmail()).orElseThrow(
+            () -> new SecurityException("Invalid access")
+        );
+        chain.doFilter(request,response);
+
+    }
+}

--- a/user-api/src/main/java/com/zerobase/cms/user/client/domain/SignInform.java
+++ b/user-api/src/main/java/com/zerobase/cms/user/client/domain/SignInform.java
@@ -1,0 +1,18 @@
+package com.zerobase.cms.user.client.domain;
+
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@Builder
+@NoArgsConstructor
+@AllArgsConstructor
+public class SignInform {
+
+    private String email;
+    private String password;
+
+
+}

--- a/user-api/src/main/java/com/zerobase/cms/user/client/domain/customer/CustomerDto.java
+++ b/user-api/src/main/java/com/zerobase/cms/user/client/domain/customer/CustomerDto.java
@@ -1,0 +1,20 @@
+package com.zerobase.cms.user.client.domain.customer;
+
+import com.zerobase.cms.user.client.domain.model.Customer;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.Setter;
+
+@Setter
+@Getter
+@AllArgsConstructor
+public class CustomerDto {
+
+    private Long id;
+    private String email;
+
+    public static CustomerDto from(Customer customer){
+       return new CustomerDto(customer.getId(), customer.getEmail());
+    }
+
+}

--- a/user-api/src/main/java/com/zerobase/cms/user/client/domain/model/Customer.java
+++ b/user-api/src/main/java/com/zerobase/cms/user/client/domain/model/Customer.java
@@ -1,6 +1,6 @@
 package com.zerobase.cms.user.client.domain.model;
 
-import com.zerobase.cms.user.client.domain.BaseEntity;
+import com.zerobase.cms.user.client.domain.repository.BaseEntity;
 import com.zerobase.cms.user.client.domain.SignUpform;
 import java.time.LocalDate;
 import java.time.LocalDateTime;

--- a/user-api/src/main/java/com/zerobase/cms/user/client/domain/repository/BaseEntity.java
+++ b/user-api/src/main/java/com/zerobase/cms/user/client/domain/repository/BaseEntity.java
@@ -1,4 +1,4 @@
-package com.zerobase.cms.user.client.domain;
+package com.zerobase.cms.user.client.domain.repository;
 
 import java.time.LocalDateTime;
 import javax.persistence.EntityListeners;

--- a/user-api/src/main/java/com/zerobase/cms/user/client/domain/repository/CustomerRepository.java
+++ b/user-api/src/main/java/com/zerobase/cms/user/client/domain/repository/CustomerRepository.java
@@ -4,8 +4,9 @@ import com.zerobase.cms.user.client.domain.model.Customer;
 import java.util.Optional;
 import org.springframework.data.jpa.repository.JpaRepository;
 
-public interface CustomRepository extends JpaRepository<Customer, Long> {
+public interface CustomerRepository extends JpaRepository<Customer, Long> {
 
     Optional<Customer> findByEmail(String email);
+
 
 }

--- a/user-api/src/main/java/com/zerobase/cms/user/client/exception/ErrorCode.java
+++ b/user-api/src/main/java/com/zerobase/cms/user/client/exception/ErrorCode.java
@@ -11,6 +11,9 @@ public enum ErrorCode {
     WRONG_VERIFICATION(HttpStatus.BAD_REQUEST,"잘못된 인증 시도입니다."),
     EXPIRE_CODE(HttpStatus.BAD_REQUEST,"인증 시간이 만료되었습니다."),
     NOT_FOUND_USER(HttpStatus.BAD_REQUEST,"일치하는 회원이 없습니다."),
+
+    //LOGIN
+    LOGIN_CHECK_FAIL(HttpStatus.BAD_REQUEST,"아이디나 패스워드를 확인해 주세요"),
     ALREADY_VERIFY(HttpStatus.BAD_REQUEST,"이미 이메일 인증이 완료되었습니다.");
 
     private final HttpStatus httpStatus;

--- a/user-api/src/main/java/com/zerobase/cms/user/client/exception/ExceptionController.java
+++ b/user-api/src/main/java/com/zerobase/cms/user/client/exception/ExceptionController.java
@@ -19,6 +19,7 @@ public class ExceptionController {
         return ResponseEntity.badRequest().body(new ExceptionResponse(c.getMessage(),c.getErrorCode()));
     }
 
+
     @Getter
     @AllArgsConstructor
     public static class ExceptionResponse {

--- a/user-api/src/main/java/com/zerobase/cms/user/client/service/CustomerService.java
+++ b/user-api/src/main/java/com/zerobase/cms/user/client/service/CustomerService.java
@@ -1,0 +1,27 @@
+package com.zerobase.cms.user.client.service;
+
+import com.zerobase.cms.user.client.domain.model.Customer;
+import com.zerobase.cms.user.client.domain.repository.CustomerRepository;
+import java.util.Optional;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+
+@Service
+@RequiredArgsConstructor
+public class CustomerService {
+
+    private final CustomerRepository customerRepository;
+
+    public Optional<Customer> findByIdAndEmail(Long id,String email){
+        return customerRepository.findById(id)
+            .stream().filter(customer ->customer.getEmail().equals(email))
+            .findFirst();
+    }
+
+    public Optional<Customer> findValidCustomer(String email, String password) {
+        return customerRepository.findByEmail(email).stream()
+            .filter(customer -> customer.getPassword().equals(password) && customer.isVerify())
+            .findFirst();
+
+    }
+}

--- a/user-api/src/main/java/com/zerobase/cms/user/client/service/SignUpCustomerService.java
+++ b/user-api/src/main/java/com/zerobase/cms/user/client/service/SignUpCustomerService.java
@@ -2,7 +2,7 @@ package com.zerobase.cms.user.client.service;
 
 import com.zerobase.cms.user.client.domain.SignUpform;
 import com.zerobase.cms.user.client.domain.model.Customer;
-import com.zerobase.cms.user.client.domain.repository.CustomRepository;
+import com.zerobase.cms.user.client.domain.repository.CustomerRepository;
 import com.zerobase.cms.user.client.exception.CustomException;
 import com.zerobase.cms.user.client.exception.ErrorCode;
 import java.time.LocalDateTime;
@@ -16,7 +16,7 @@ import org.springframework.stereotype.Service;
 @RequiredArgsConstructor
 public class SignUpCustomerService {
 
-    private final CustomRepository customRepository;
+    private final CustomerRepository customRepository;
 
     public Customer signUp(SignUpform form) {
         return customRepository.save(Customer.from(form));

--- a/user-api/src/main/java/com/zerobase/cms/user/controller/CustomerController.java
+++ b/user-api/src/main/java/com/zerobase/cms/user/controller/CustomerController.java
@@ -1,0 +1,37 @@
+package com.zerobase.cms.user.controller;
+
+import com.zerobase.cms.user.client.domain.customer.CustomerDto;
+import com.zerobase.cms.user.client.domain.model.Customer;
+import com.zerobase.cms.user.client.exception.CustomException;
+import com.zerobase.cms.user.client.exception.ErrorCode;
+import com.zerobase.cms.user.client.service.CustomerService;
+import com.zerobase.domain.common.UserVo;
+import com.zerobase.domain.config.JwtAuthenticationProvider;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RequestHeader;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@RequiredArgsConstructor
+@RequestMapping(value = "/customer")
+public class CustomerController {
+
+    private final JwtAuthenticationProvider provider;
+
+    private final CustomerService customerService;
+
+    @GetMapping("/getInfo")
+    public ResponseEntity<CustomerDto> getInfo(@RequestHeader(name = "X-AUTH-TOKEN") String token){
+        UserVo vo = provider.getUserVo(token);
+        Customer c = customerService.findByIdAndEmail(vo.getId(),vo.getEmail()).orElseThrow(
+            () -> new CustomException(ErrorCode.NOT_FOUND_USER));
+
+        return ResponseEntity.ok(CustomerDto.from(c));
+
+    }
+
+
+}

--- a/user-api/src/main/java/com/zerobase/cms/user/controller/SignInController.java
+++ b/user-api/src/main/java/com/zerobase/cms/user/controller/SignInController.java
@@ -1,0 +1,24 @@
+package com.zerobase.cms.user.controller;
+
+import com.zerobase.cms.user.application.SignInApplication;
+import com.zerobase.cms.user.client.domain.SignInform;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@RequiredArgsConstructor
+@RequestMapping(value = "/signIn")
+public class SignInController {
+
+    private final SignInApplication signInApplication;
+
+    @PostMapping("/customer")
+    public ResponseEntity<String> signInCustomer(@RequestBody SignInform form) {
+        return ResponseEntity.ok(signInApplication.customerLoginToken(form));
+    }
+
+}

--- a/zerobase-domain/src/main/java/com/zerobase/domain/common/UserType.java
+++ b/zerobase-domain/src/main/java/com/zerobase/domain/common/UserType.java
@@ -1,0 +1,5 @@
+package com.zerobase.domain.common;
+
+public enum UserType {
+    CUSTOMER,SELLER
+}

--- a/zerobase-domain/src/main/java/com/zerobase/domain/common/UserVo.java
+++ b/zerobase-domain/src/main/java/com/zerobase/domain/common/UserVo.java
@@ -1,0 +1,13 @@
+package com.zerobase.domain.common;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+
+@Getter
+@AllArgsConstructor
+public class UserVo {
+
+    private Long id;
+    private String email;
+
+}

--- a/zerobase-domain/src/main/java/com/zerobase/domain/config/JwtAuthenticationProvider.java
+++ b/zerobase-domain/src/main/java/com/zerobase/domain/config/JwtAuthenticationProvider.java
@@ -1,0 +1,43 @@
+package com.zerobase.domain.config;
+
+import com.zerobase.domain.common.UserType;
+import com.zerobase.domain.common.UserVo;
+import com.zerobase.domain.util.Aes256Util;
+import io.jsonwebtoken.Claims;
+import io.jsonwebtoken.Jws;
+import io.jsonwebtoken.Jwts;
+import io.jsonwebtoken.SignatureAlgorithm;
+import java.util.Date;
+import java.util.Objects;
+
+public class JwtAuthenticationProvider {
+    private final String secretKey = "secretKey";
+
+    private long tokenValidTime = 1000L * 60 * 60 * 24;
+
+    public String createToken(String userPk, Long id, UserType userType){
+        Claims claims = Jwts.claims().setSubject(Aes256Util.encrypt(userPk)).setId(Aes256Util.encrypt(id.toString()));
+        claims.put("roles",userType);
+        Date now  = new Date();
+        return Jwts.builder()
+            .setClaims(claims)
+            .setIssuedAt(now)
+            .setExpiration(new Date(now.getTime()+tokenValidTime))
+            .signWith(SignatureAlgorithm.HS256,secretKey)
+            .compact();
+    }
+
+    public boolean validateToken(String jwtToken) {
+        try{
+            Jws<Claims> claimsJws = Jwts.parser().setSigningKey(secretKey).parseClaimsJws(jwtToken);
+            return !claimsJws.getBody().getExpiration().before(new Date());
+        }catch (Exception e) {
+            return false;
+        }
+    }
+
+    public UserVo getUserVo(String token) {
+        Claims c = Jwts.parser().setSigningKey(secretKey).parseClaimsJws(token).getBody();
+        return new UserVo(Long.valueOf(Objects.requireNonNull(Aes256Util.decrypt(c.getId()))),Aes256Util.decrypt(c.getSubject()));
+    }
+}

--- a/zerobase-domain/src/main/java/com/zerobase/domain/util/Aes256Util.java
+++ b/zerobase-domain/src/main/java/com/zerobase/domain/util/Aes256Util.java
@@ -1,0 +1,43 @@
+package com.zerobase.domain.util;
+
+import java.nio.charset.StandardCharsets;
+import javax.crypto.Cipher;
+import javax.crypto.spec.IvParameterSpec;
+import javax.crypto.spec.SecretKeySpec;
+import org.apache.tomcat.util.codec.binary.Base64;
+
+public class Aes256Util {
+    public static String alg = "AES/CBC/PKCS5Padding";
+    private static final String KEY = "ZEROBASEKEYISZEROBASEKEY";
+    private static String IV = KEY.substring(0,16);
+
+    public static String encrypt(String text){
+        try {
+            Cipher cipher = Cipher.getInstance(alg);
+            SecretKeySpec keySpec = new SecretKeySpec(KEY.getBytes(),"AES");
+            IvParameterSpec ivParameterSpec = new IvParameterSpec(IV.getBytes());
+            cipher.init(Cipher.ENCRYPT_MODE,keySpec,ivParameterSpec);
+            byte[] encrypted = cipher.doFinal(text.getBytes(StandardCharsets.UTF_8));
+            return Base64.encodeBase64String(encrypted);
+
+        } catch (Exception e) {
+            return null;
+        }
+    }
+
+    public static String decrypt(String cipherText) {
+        try {
+            Cipher cipher = Cipher.getInstance(alg);
+            SecretKeySpec keySpec = new SecretKeySpec(KEY.getBytes(),"AES");
+            IvParameterSpec ivParameterSpec = new IvParameterSpec(IV.getBytes(StandardCharsets.UTF_8));
+            cipher.init(Cipher.DECRYPT_MODE,keySpec,ivParameterSpec);
+
+            byte[] decodedBytes = Base64.decodeBase64(cipherText);
+            byte[] decrypted = cipher.doFinal(decodedBytes);
+            return new String(decrypted,StandardCharsets.UTF_8);
+        }catch (Exception e){
+            return null;
+        }
+    }
+
+}

--- a/zerobase-domain/src/test/java/com/zerobase/domain/util/Aes256UtilTest.java
+++ b/zerobase-domain/src/test/java/com/zerobase/domain/util/Aes256UtilTest.java
@@ -1,0 +1,14 @@
+package com.zerobase.domain.util;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+import org.junit.jupiter.api.Test;
+
+class Aes256UtilTest {
+    @Test
+    void encrypt() {
+        String encrypt = Aes256Util.encrypt("Hello world");
+        assertEquals(Aes256Util.decrypt(encrypt),"Hello world");
+    }
+
+}


### PR DESCRIPTION
JWT의 내부 암호화
/customer/*에 대한 token filter 적용

## Summary
1. Login을 통한 토큰 발행
2. /customer/* 에 대한 토큰 filter 적용

## Describe your changes


## Issue number and link

--
토큰으로부터 User의 Id값을 가져오는데에 Aes256Util  -> encrypt를 깜박했다....
그래서 로그인 후 토큰을 발행하여 토큰으로부터 유저의 값을 가져오는데 계속 실패하여 고생했다.
